### PR TITLE
[SPIKE] Add IdentitiesHelper::NewIdenentiyView class.

### DIFF
--- a/app/helpers/identities_helper.rb
+++ b/app/helpers/identities_helper.rb
@@ -1,0 +1,35 @@
+require "active_support/core_ext/object/try"
+
+# IdentitiesHelper contains the view classes used in each view located in
+# identities/view.
+#
+module IdentitiesHelper
+
+  # NewIdentityView is the view class used in views/identities/new
+  #
+  class NewIdentityView
+    def initialize(identity)
+      @identity = identity
+    end
+
+    def email
+      @identity.try(:email)
+    end
+
+    def errors?
+      @identity.try(:errors).try(:any?)
+    end
+
+    def error_count
+      @identity.try(:errors).try(:count) || 0
+    end
+
+    def full_messages
+      @identity.try(:errors).try(:full_messages) || []
+    end
+
+    def name
+      @identity.try(:name)
+    end
+  end
+end

--- a/app/views/identities/new.html.erb
+++ b/app/views/identities/new.html.erb
@@ -1,9 +1,11 @@
+<% view = IdentitiesHelper::NewIdentityView.new(@identity) %>
+
 <%= form_tag registration_path do %>
-  <% if @identity && @identity.errors.any? %>
+  <% if view.errors? %>
     <div class="error_messages">
-      <h2><%= t(".error_count", count: @identity.errors.count) %></h2>
+      <h2><%= t(".error_count", count: view.error_count) %></h2>
       <ul>
-        <% @identity.errors.full_messages.each do |msg| %>
+        <% view.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
       </ul>
@@ -11,11 +13,11 @@
   <% end %>
   <div class="field">
     <%= label_tag :name %><br>
-    <%= text_field_tag :name, @identity.try(:name) %>
+    <%= text_field_tag :name, view.name %>
   </div>
   <div class="field">
     <%= label_tag :email %><br>
-    <%= text_field_tag :email, @identity.try(:email) %>
+    <%= text_field_tag :email, view.email %>
   </div>
   <div class="field">
     <%= label_tag :password %><br>

--- a/spec/helpers/identities_helper_spec.rb
+++ b/spec/helpers/identities_helper_spec.rb
@@ -1,0 +1,106 @@
+require_relative "../../app/helpers/identities_helper"
+
+describe "IdentitiesHelper::NewIdentityView" do
+  let(:new_identity_view) { IdentitiesHelper::NewIdentityView.new(identity) }
+
+  context "when identity is nil" do
+    let(:identity) { nil }
+
+    describe "email" do
+      subject { new_identity_view.email }
+
+      it { should be_nil }
+    end
+
+    describe "errors?" do
+      subject { new_identity_view.errors? }
+
+      it { should be_false }
+    end
+
+    describe "error_count" do
+      subject { new_identity_view.error_count }
+
+      it { should == 0 }
+    end
+
+    describe "full_messages" do
+      subject { new_identity_view.full_messages }
+
+      it { should == [] }
+    end
+
+    describe "name" do
+      subject { new_identity_view.name }
+
+      it { should be_nil }
+    end
+  end
+
+  context "when identity is set" do
+    let(:identity) { double(:identity,  name: name,
+                                        email: email,
+                                        errors: errors,
+                           ) }
+    let(:name) { "name" }
+    let(:email) { "email" }
+    let(:errors) { [] }
+
+    describe "email" do
+      subject { new_identity_view.email }
+
+      it { should == email }
+    end
+
+    describe "errors?" do
+      subject { new_identity_view.errors? }
+
+      it { should be_false }
+    end
+
+    describe "error_count" do
+      subject { new_identity_view.error_count }
+
+      it { should == 0 }
+    end
+
+    describe "full_messages" do
+      subject { new_identity_view.full_messages }
+
+      it { should == [] }
+    end
+
+    describe "name" do
+      subject { new_identity_view.name }
+
+      it { should == name }
+    end
+
+    context "and has errors" do
+      let(:errors) { double(:errors,  any?: true,
+                                      count: count,
+                                      full_messages: full_messages,
+                            ) }
+      let(:count) { 2 }
+      let(:full_messages) { [1,2] }
+
+      describe "errors?" do
+        subject { new_identity_view.errors? }
+
+        it { should be_true }
+      end
+
+      describe "error_count" do
+        subject { new_identity_view.error_count }
+
+        it { should == count }
+      end
+
+      describe "full_messages" do
+        subject { new_identity_view.full_messages }
+
+        it { should == full_messages }
+      end
+    end
+  end
+end


### PR DESCRIPTION
I had a spike on building a must ache style ERB view.

---

IdentitiesHelper::NewIdenentityView  is instantiated in the views/identitites/new template and contains all of the logic required to render the view.

It's 100% unit tested using stubs and no spec_helper.rb, which means the tests are lightning fast:

```
☁  aerobic.io [mustache-style-erb] rspec -fd spec/helpers/identities_helper_spec.rb 

IdentitiesHelper::NewIdentityView
  when identity is nil
    email
      should be nil
    errors?
      should be false
    error_count
      should == 0
    full_messages
      should == []
    name
      should be nil
  when identity is set
    email
      should == "email"
    errors?
      should be false
    error_count
      should == 0
    full_messages
      should == []
    name
      should == "name"
    and has errors
      errors?
        should be true
      error_count
        should == 2
      full_messages
        should == [1, 2]

Finished in 0.01056 seconds
13 examples, 0 failures
```

The template now has fewer method calls inside of it, and the errors section is screaming to be abstracted into a partial with it's own view helper. Maybe a generic ErrorsView class, or FormErrorsView class. Not sure, probably overkill for now as this is our only form other than sign in.
