### PR TITLE
Add meta[name='viewport']

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title><%= area :title, t("title") %></title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width">
 
   <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>


### PR DESCRIPTION
This PR adds the `meta[name='viewport']` tag to all pages on the site—meaning the layout should respond to device size now.
