### PR TITLE
Use the asset host defined by ASSET_HOST environment variable in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ AerobicIo::Application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
+  config.action_controller.asset_host = ENV["ASSET_HOST"]
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
This PR is pretty simple. It sets the asset host to whatever the ASSET_HOST env var is.

I've already updated beta-aerobic to have the ASSET_HOST set to d1afj73secznmf.cloudfront.net which is a new cloud front distribution set up for beta.
