### PR TITLE
CI Stats

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -52,7 +52,7 @@ build:
             name: best practices
             code: bundle exec rails_best_practices .
     after-steps:
-        - plasticine/librato-build-metrics@0.0.14:
+        - plasticine/librato-build-metrics@0.0.15:
             user: $LIBRATO_USER
             token: $LIBRATO_TOKEN
             namespace: aerobicio


### PR DESCRIPTION
The PR adds a new `after-step` to our wercker config that will log some basic stats about the build to our librato account, namely;
- build duration,
- passing builds
- failing builds

:dancer: 
