### PR TITLE
Redirect authenticated members to the dashboard when they visit the home page.

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -5,7 +5,14 @@
 #
 class HomesController < ApplicationController
   skip_before_filter :login_required
+  before_filter :redirect_members_to_dashboard
 
   def new
+  end
+
+  private
+
+  def redirect_members_to_dashboard
+    redirect_to dashboard_path and return if current_user
   end
 end

--- a/spec/controllers/homes_controller_spec.rb
+++ b/spec/controllers/homes_controller_spec.rb
@@ -1,12 +1,29 @@
 require 'spec_helper'
 
 describe HomesController do
-  describe "#show" do
-    before do
-      get :show
-    end
+  context "when not authenticated" do
+    describe "#show" do
+      before do
+        get :show
+      end
 
-    it { should respond_with(:success) }
-    it { should render_template(:show) }
+      it { should respond_with(:success) }
+      it { should render_template(:show) }
+    end
+  end
+
+  context "when already authenticated" do
+    describe "#show" do
+      let(:user) { double(User, id: 42) }
+
+      before do
+        session[:user_id] = 42
+        User.stub(:find).and_return(user)
+
+        get :show
+      end
+
+      it { should redirect_to(dashboard_path) }
+    end
   end
 end


### PR DESCRIPTION
This PR changes the behaviour of the <code>HomesController</code> to redirect an authenticated user to their dashboard.

I chose not to redirect <code>SessionsController</code> because I figured it's unlikely that a user will visit it and if they do, they can just sign in and everything will work normally.

Fixes #106 
