### PR TITLE
Correct the order of params passed into the following_link_for_members helper.

### DIFF
--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -4,7 +4,7 @@
     <div class="media__content">
       <h1><%= @member.name %></h1>
       <div class="member-following">
-        <%= following_link_for_members(@member, current_user) %>
+        <%= following_link_for_members(current_user, @member) %>
       </div>
     </div>
   </header>


### PR DESCRIPTION
This PR fixes #135 by changing the order of the parameters passed into the following_link_for_members helper.

This may also be related to the strange following activity items generated as detailed in #136.
