### PR TITLE
Only add to followers activity feed if the follower is not the one followed.

### DIFF
--- a/app/interactors/add_following_to_activity_feeds.rb
+++ b/app/interactors/add_following_to_activity_feeds.rb
@@ -34,8 +34,16 @@ class AddFollowingToActivityFeeds
 
   def add_to_members_followers_activity_feed
     member.followers.inject(true) do |success, follower|
-      add_to_activity_feed(follower.id) && success
+      if followed_member?(follower.id)
+        success
+      else
+        add_to_activity_feed(follower.id) && success
+      end
     end
+  end
+
+  def followed_member?(follower_id)
+    followed_id == followed_id.to_i
   end
 
   def add_to_activity_feed(user_id)

--- a/spec/interactors/add_following_to_activity_feeds_spec.rb
+++ b/spec/interactors/add_following_to_activity_feeds_spec.rb
@@ -60,9 +60,6 @@ describe AddFollowingToActivityFeeds do
       before do
         Activity::FollowedUser.should_receive(:create).
           with(followed_member_feed) { activity }
-
-        Activity::FollowedUser.should_receive(:create).
-          with(follower_member_feed) { activity }
       end
 
       it "should be marked as successfull" do


### PR DESCRIPTION
Fixes #136 

It was possible to have a double entry in the activity feed when being followed by someone you were already following. This change prevents the second Follow event from being added to the feed.
