### PR TITLE
Only render FollowedUser and UnfollowedUser partials if following is on.

### DIFF
--- a/app/views/activity/followed_users/_followed_user.html.erb
+++ b/app/views/activity/followed_users/_followed_user.html.erb
@@ -1,13 +1,15 @@
-<% cache "#{current_user.cache_key}:#{followed_user.cache_key}" do %>
-  <article class="panel">
-    <ul class="panel__content">
-      <% if current_user.id == followed_user.activity_user_id %>
-        You followed <%= followed_user.activity_followed_user.name %>
-      <% elsif current_user.id == followed_user.activity_followed_user_id %>
-        <%= followed_user.activity_user.name %> followed you
-      <% else %>
-        <%= followed_user.activity_user.name %> followed <%= followed_user.activity_followed_user.name %>
-      <% end %>
-    </ul>
-  </article>
+<% cache "#{$switch_board.following_active?(current_user)}:#{current_user.cache_key}:#{followed_user.cache_key}" do %>
+  <% if $switch_board.following_active?(current_user) %>
+    <article class="panel">
+      <ul class="panel__content">
+        <% if current_user.id == followed_user.activity_user_id %>
+          You followed <%= followed_user.activity_followed_user.name %>
+        <% elsif current_user.id == followed_user.activity_followed_user_id %>
+          <%= followed_user.activity_user.name %> followed you
+        <% else %>
+          <%= followed_user.activity_user.name %> followed <%= followed_user.activity_followed_user.name %>
+        <% end %>
+      </ul>
+    </article>
+  <% end %>
 <% end %>

--- a/app/views/activity/unfollowed_users/_unfollowed_user.html.erb
+++ b/app/views/activity/unfollowed_users/_unfollowed_user.html.erb
@@ -1,7 +1,9 @@
-<% cache unfollowed_user do %>
-  <article class="panel">
-    <div class="panel__content">
-      No longer following <%= unfollowed_user.activity_followed_user.name %>
-    </div>
-  </article>
+<% cache "#{$switch_board.following_active?(current_user)}:#{unfollowed_user.cache_key}" do %>
+  <% if $switch_board.following_active?(current_user) %>
+    <article class="panel">
+      <div class="panel__content">
+        No longer following <%= unfollowed_user.activity_followed_user.name %>
+      </div>
+    </article>
+  <% end %>
 <% end %>

--- a/features/step_definitions/following_steps.rb
+++ b/features/step_definitions/following_steps.rb
@@ -40,33 +40,41 @@ When(/^I follow "(.*?)"$/) do |name|
 end
 
 Then(/^I should see that fact in my activity feed$/) do
+  $switch_board.activate_following
   visit dashboard_path
   page.should have_content "You followed #{@name}"
+  $switch_board.deactivate_following
 end
 
 Then(/^"(.*?)" should see that I followed them in their activity feed$/) do |name|
+  $switch_board.activate_following
   Capybara.session_name = name
   visit dashboard_path
   page.should have_content "#{@my_name} followed you"
+  $switch_board.deactivate_following
 end
 
 Then(/^"(.*?)" should see that I followed "(.*?)" in their activity feed$/) do |name, followed_name|
+  $switch_board.activate_following
   Capybara.session_name = name
   visit dashboard_path
   page.should have_content "#{@my_name} followed #{followed_name}"
+  $switch_board.deactivate_following
 end
 
 When(/^I unfollow "(.*?)"$/) do |name|
-  @name = name
   $switch_board.activate_following
+  @name = name
   visit members_path
   click_button "Unfollow #{name}"
   $switch_board.deactivate_following
 end
 
 Then(/^I should see that I unfollowed "(.*?)" in my activity feed$/) do |name|
+  $switch_board.activate_following
   visit dashboard_path
   page.should have_content "No longer following #{@name}"
+  $switch_board.deactivate_following
 end
 
 Then(/^"(.*?)" should not see that fact in their activity feed$/) do |name|


### PR DESCRIPTION
Fixes #143 

This PR makes it so that the partials for FollowedUser and UnfollowedUser are only rendered if following is turned on for the current user.

This means that users who do not have the feature turned on will not see it and potentially be confused by it. 
