### PR TITLE
Add member context to the added workout partial.

### DIFF
--- a/app/views/activity/added_workouts/_added_workout.html.erb
+++ b/app/views/activity/added_workouts/_added_workout.html.erb
@@ -1,6 +1,15 @@
 <% cache "#{added_workout.cache_key}:#{added_workout.activity_workout.cache_key}" do %>
   <article class="panel">
     <ul class="panel__content">
+      <p>
+        <% if current_user == added_workout.user %>
+          "You"
+        <% else %>
+          <%= added_workout.user.name %>
+        <% end %>
+
+        " did a workout:"
+      </p>
       <li><strong>Duration:</strong> <%= (added_workout.activity_workout.active_duration / 1000 / 60.0).round(2) %> minutes</li>
       <li><strong>Distance:</strong> <%= (added_workout.activity_workout.distance / 100000.0).round(2) %>km</li>
     </ul>


### PR DESCRIPTION
Fixes #150 

This just adds a simple paragraph to the top of the added workout partial to give it some context on the user who performed the task.

I'm sure we'll make it better when we bite off #130 but this should do for now.
