### PR TITLE
Enforce JS coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development, :test do
   gem "kayessess", "~> 0.2.0"
   gem "rails_best_practices"
   gem "rspec-rails", "~> 2.0"
-  gem "teaspoon"
+  gem "teaspoon", "~> 0.7.8"
 end
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       multi_json (~> 1.3)
     hashie (2.0.5)
     hike (1.2.3)
-    i18n (0.6.8)
+    i18n (0.6.9)
     interactor (2.1.0)
     interactor-rails (1.0.1)
       interactor (< 3)
@@ -162,7 +162,7 @@ GEM
       omniauth (~> 1.0)
     parallel (0.9.0)
     pg (0.17.0)
-    phantomjs (1.9.2.0)
+    phantomjs (1.9.2.1)
     polyglot (0.3.3)
     posix-spawn (0.3.6)
     prototype-rails (3.2.0)
@@ -205,7 +205,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.12.0)
-    rake (10.1.0)
+    rake (10.1.1)
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.0.0)
@@ -264,7 +264,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    teaspoon (0.7.7)
+    teaspoon (0.7.8)
       phantomjs (>= 1.8.1.1)
       railties (>= 3.2.5, < 5)
     terminal-notifier (1.4.2)
@@ -342,7 +342,7 @@ DEPENDENCIES
   sentry-raven
   shoulda-matchers
   simplecov
-  teaspoon
+  teaspoon (~> 0.7.8)
   turbolinks
   typogruby
   uglifier (>= 1.3.0)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "bower": "~1.2.6",
-    "istanbul": "~0.1.44"
+    "istanbul": "~0.1.46"
   },
   "devDependencies": {},
   "scripts": {

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -32,4 +32,8 @@ Teaspoon.setup do |config|
   # Coverage (requires istanbul -- https://github.com/gotwarlost/istanbul)
   config.coverage         = true
   config.coverage_reports = "text,html"
+  config.statements_coverage_threshold = 100
+  config.functions_coverage_threshold  = 94
+  config.branches_coverage_threshold   = 83
+  config.lines_coverage_threshold      = 100
 end


### PR DESCRIPTION
This PR bumps teaspoon to `0.7.8`, and enables coverage threshold checking.
