### PR TITLE
PROPOSAL: Only run consistency fail migration enforcing when in test env.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby "2.0.0", :patchlevel => "353"
 gem "bcrypt-ruby", "~> 3.1.2"
 gem "bindata"
 gem "bourbon"
-gem "consistency_fail"
 gem "dalli"
 gem "fit", git: "https://github.com/aerobicio/fit.git"
 gem "foreigner"
@@ -49,13 +48,14 @@ end
 
 group :test do
   gem "codeclimate-test-reporter", require: nil
+  gem "consistency_fail"
   gem "cucumber-nc"
   gem "cucumber-rails", :require => false
   gem "database_cleaner"
   gem "faker"
   gem "rspec-nc"
-  gem "simplecov", :require => false
   gem "shoulda-matchers"
+  gem "simplecov", :require => false
 end
 
 group :production do

--- a/config/initializers/consistency_fail.rb
+++ b/config/initializers/consistency_fail.rb
@@ -1,4 +1,4 @@
-unless Rails.env.production?
+if defined?(ConsistencyFail)
   require 'consistency_fail/enforcer'
   ConsistencyFail::Enforcer.enforce!
 end


### PR DESCRIPTION
This removes the consistency_fail enforcer when in development, making it only run when in test mode.

If I understand the intention of this tool correctly we will still get all the benefits of consistency_fail by only enforcing checks in the `test` env, and not have to deal with the inconvenience of having it in the `development` env.

I find it makes evaluating a WIP PR (where index are maybe not added yet) much more of a PITA, and given that we will never let a failing branch of code get into master it seems redundant anyway.

Thoughts?
