### PR TITLE
Prevent extra unexpected toggles when navigating.

### DIFF
--- a/app/assets/javascripts/application/controllers/responsive_navigation_controller.coffee
+++ b/app/assets/javascripts/application/controllers/responsive_navigation_controller.coffee
@@ -19,7 +19,7 @@
     @toggleNavigationState()
 
   _onPageChange: =>
-    @toggleNavigationState()
+    @toggleNavigationState() if @isExpanded()
 
   toggleNavigationState: ->
     @$bannerEl.toggleClass('is-expanded')


### PR DESCRIPTION
Caught a bug that slipped through the responsive stuff that is caused by me misunderstanding Turbolinks. Whoops.
