### PR TITLE
Remove following feature flip. It is now permanently on.

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,8 +1,6 @@
 # MembersController provides a restful interface onto the Member resource.
 #
 class MembersController < ApplicationController
-  before_action :ensure_following_is_active, only: [:follow, :unfollow]
-
   def index
     @view = Members::Index.new(self, current_user)
   end
@@ -44,13 +42,5 @@ class MembersController < ApplicationController
       fail ActiveRecord::Rollback unless result.success?
     end
     notice
-  end
-
-  def ensure_following_is_active
-    render_404 && return unless $switch_board.following_active?(current_user)
-  end
-
-  def render_404
-    render file: "#{Rails.root}/public/404.html", status: :not_found
   end
 end

--- a/app/helpers/following_helper.rb
+++ b/app/helpers/following_helper.rb
@@ -3,8 +3,6 @@
 #
 module FollowingHelper
   def following_link_for_members(member, other_member)
-    return unless $switch_board.following_active?(member)
-
     if members_are_different(member, other_member)
       if member.follows?(other_member)
         unfollow_button_for(other_member)
@@ -15,8 +13,6 @@ module FollowingHelper
   end
 
   def member_relationship_status_for_members(member, other_member)
-    return unless $switch_board.following_active?(member)
-
     if other_member.follows?(member)
       "#{other_member.name} follows you"
     else

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -14,10 +14,6 @@ class Activity < ActiveRecord::Base
 
   default_scope { order(created_at: :desc) }
 
-  scope :exclude_following, lambda {
-    where.not(type: ['Activity::FollowedUser', 'Activity::UnfollowedUser'])
-  }
-
   def date
     created_at.try(:to_date)
   end

--- a/app/view_controllers/dashboards/show.rb
+++ b/app/view_controllers/dashboards/show.rb
@@ -32,11 +32,7 @@ module Dashboards
     end
 
     def member_activities
-      if $switch_board.following_active?(@member)
-        @member.activities
-      else
-        @member.activities.exclude_following
-      end
+      @member.activities
     end
   end
 end

--- a/features/following.feature
+++ b/features/following.feature
@@ -7,45 +7,17 @@ Feature: Following
     Given I am a member
     And "Justin" is following me
 
-  @flip @following @off
-  Scenario: A member cannot unfollow another member when the feature is off
-    Given I am following "Justin"
-    And the following feature is off
-    Then I should not be able to unfollow "Justin"
-
-  @flip @following @off
-  Scenario: A member cannot follow another member when the feature is off
-    Given I am not following "Justin"
-    And the following feature is off
-    Then I should not be able to follow "Justin"
-
-  @flip @following @on
+  @following
   Scenario: A member can follow another member when the feature is on
-    Given the following feature is on
-    When I follow "Gus"
+    Given I follow "Gus"
     Then I should see that fact in my activity feed
     And "Gus" should see that I followed them in their activity feed
     And "Justin" should see that I followed "Gus" in their activity feed
 
-  @flip @following @on
+  @following
   Scenario: A member can unfollow another member when the feature is on
-    Given the following feature is on
-    And I follow "Gus"
+    Given I follow "Gus"
     When I unfollow "Gus"
     Then I should see that I unfollowed "Gus" in my activity feed
     And "Gus" should not see that fact in their activity feed
     And "Justin" should not see that fact in their activity feed
-
-  @flip @following @off
-  Scenario: A member cannot unfollow another member from the profile page when the feature is off
-    Given I am following "Justin"
-    And the following feature is off
-    When I visit "Justin"’s profile
-    Then I should not be able to unfollow "Justin"
-
-  @flip @following @off
-  Scenario: A member cannot follow another member from the profile page when the feature is off
-    Given I am not following "Justin"
-    And the following feature is off
-    When I visit "Justin"’s profile
-    Then I should not be able to follow "Justin"

--- a/features/step_definitions/following_steps.rb
+++ b/features/step_definitions/following_steps.rb
@@ -9,26 +9,8 @@ Given(/^I am following "(.*?)"$/) do |name|
   follow(name)
 end
 
-Given(/^the following feature is off$/) do
-  $switch_board.deactivate_following
-end
-
-Then(/^I should not be able to unfollow "(.*?)"$/) do |name|
-  visit members_path
-  page.should have_no_content('Unfollow')
-end
-
 Given(/^I am not following "(.*?)"$/) do |name|
   # This is the default state
-end
-
-Then(/^I should not be able to follow "(.*?)"$/) do |name|
-  visit members_path
-  page.should have_no_content('Follow')
-end
-
-Given(/^the following feature is on$/) do
-  $switch_board.activate_following
 end
 
 When(/^I follow "(.*?)"$/) do |name|
@@ -40,41 +22,31 @@ When(/^I follow "(.*?)"$/) do |name|
 end
 
 Then(/^I should see that fact in my activity feed$/) do
-  $switch_board.activate_following
   visit dashboard_path
   page.should have_content "You followed #{@name}"
-  $switch_board.deactivate_following
 end
 
 Then(/^"(.*?)" should see that I followed them in their activity feed$/) do |name|
-  $switch_board.activate_following
   Capybara.session_name = name
   visit dashboard_path
   page.should have_content "#{@my_name} followed you"
-  $switch_board.deactivate_following
 end
 
 Then(/^"(.*?)" should see that I followed "(.*?)" in their activity feed$/) do |name, followed_name|
-  $switch_board.activate_following
   Capybara.session_name = name
   visit dashboard_path
   page.should have_content "#{@my_name} followed #{followed_name}"
-  $switch_board.deactivate_following
 end
 
 When(/^I unfollow "(.*?)"$/) do |name|
-  $switch_board.activate_following
   @name = name
   visit members_path
   click_button "Unfollow #{name}"
-  $switch_board.deactivate_following
 end
 
 Then(/^I should see that I unfollowed "(.*?)" in my activity feed$/) do |name|
-  $switch_board.activate_following
   visit dashboard_path
   page.should have_content "No longer following #{@name}"
-  $switch_board.deactivate_following
 end
 
 Then(/^"(.*?)" should not see that fact in their activity feed$/) do |name|
@@ -85,8 +57,6 @@ end
 
 def follow(name)
   @name = name
-  $switch_board.activate_following
   visit members_path
   click_button "Follow #{name}"
-  $switch_board.deactivate_following
 end

--- a/lib/switch_board.rb
+++ b/lib/switch_board.rb
@@ -13,7 +13,7 @@ class SwitchBoard
     @rollout = rollout
   end
 
-  FEATURE_FLIPS = [:sign_up, :following]
+  FEATURE_FLIPS = [:sign_up]
 
   FEATURE_FLIPS.each do |flip_name|
     define_method "activate_#{flip_name}" do |group = :all|

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -29,62 +29,36 @@ describe MembersController do
     it { should render_template(:show) }
   end
 
+  @following
   describe 'follow' do
-    @following
-    context 'when following is turned off' do
-      before do
-        $switch_board.deactivate_following
-        post :follow, id: 22
-      end
-
-      it { should respond_with(:not_found) }
+    before do
+      FollowMember.should_receive(:perform) { result }
+      post :follow, id: 22
     end
 
-    @following
-    context 'when following is turned on' do
-      before do
-        $switch_board.activate_following
-        FollowMember.should_receive(:perform) { result }
-        post :follow, id: 22
-      end
-
-      let(:result) do
-        double(:result, success?: true,
-                        notice: 'My Notice')
-      end
-
-      it { should set_the_flash[:notice].to('My Notice') }
-      it { should redirect_to(members_path) }
+    let(:result) do
+      double(:result, success?: true,
+                      notice: 'My Notice')
     end
+
+    it { should set_the_flash[:notice].to('My Notice') }
+    it { should redirect_to(members_path) }
   end
 
+  @following
   describe 'unfollow' do
-    @following
-    context 'when following is turned off' do
-      before do
-        $switch_board.deactivate_following
-        post :unfollow, id: 22
-      end
-
-      it { should respond_with(:not_found) }
+    before do
+      UnFollowMember.should_receive(:perform) { result }
+      post :unfollow, id: 22
     end
 
-    @following
-    context 'when following is turned on' do
-      before do
-        $switch_board.activate_following
-        UnFollowMember.should_receive(:perform) { result }
-        post :unfollow, id: 22
-      end
-
-      let(:result) do
-        double(:result, success?: true,
-                        notice: 'My Notice')
-      end
-
-      it { should set_the_flash[:notice].to('My Notice') }
-
-      it { should redirect_to(members_path) }
+    let(:result) do
+      double(:result, success?: true,
+                      notice: 'My Notice')
     end
+
+    it { should set_the_flash[:notice].to('My Notice') }
+
+    it { should redirect_to(members_path) }
   end
 end

--- a/spec/helpers/following_helper_spec.rb
+++ b/spec/helpers/following_helper_spec.rb
@@ -2,55 +2,42 @@ require 'spec_helper'
 
 include FollowingHelper
 
+@following
 describe FollowingHelper do
   describe '#following_link_for_members' do
     subject { following_link_for_members(member, other_member) }
     let(:member) { double(:member, id: 1, name: 'Justin Morris') }
     let(:other_member) { double(:other_member, id: 2, name: 'Gus Gollings') }
 
-    context 'when following is inactive' do
-      before do
-        $switch_board.stub(:following_active?) { false }
-      end
+    describe 'when both members are the same member' do
+      let(:other_member) { member }
 
       it { should be_nil }
     end
 
-    context 'when following is active' do
+    describe 'when the member already follows the other member' do
       before do
-        $switch_board.stub(:following_active?) { true }
+        member.stub(:follows?).with(other_member) { true }
       end
 
-      describe 'when both members are the same member' do
-        let(:other_member) { member }
+      it do
+        should == "<form action=\"/members/2/unfollow\" class=\"button_to\" "\
+                  "method=\"post\"><div><input class=\"button--follow\" "\
+                  "type=\"submit\" value=\"Unfollow Gus Gollings\" "\
+                  "/></div></form>"
+      end
+    end
 
-        it { should be_nil }
+    describe 'when the member does not follow the other member' do
+      before do
+        member.stub(:follows?).with(other_member) { false }
       end
 
-      describe 'when the member already follows the other member' do
-        before do
-          member.stub(:follows?).with(other_member) { true }
-        end
-
-        it do
-          should == "<form action=\"/members/2/unfollow\" class=\"button_to\" "\
-                    "method=\"post\"><div><input class=\"button--follow\" "\
-                    "type=\"submit\" value=\"Unfollow Gus Gollings\" "\
-                    "/></div></form>"
-        end
-      end
-
-      describe 'when the member does not follow the other member' do
-        before do
-          member.stub(:follows?).with(other_member) { false }
-        end
-
-        it do
-          should == "<form action=\"/members/2/follow\" class=\"button_to\" "\
-                    "method=\"post\"><div><input class=\"button--follow\" "\
-                    "type=\"submit\" value=\"Follow Gus Gollings\" "\
-                    "/></div></form>"
-        end
+      it do
+        should == "<form action=\"/members/2/follow\" class=\"button_to\" "\
+                  "method=\"post\"><div><input class=\"button--follow\" "\
+                  "type=\"submit\" value=\"Follow Gus Gollings\" "\
+                  "/></div></form>"
       end
     end
   end
@@ -60,34 +47,20 @@ describe FollowingHelper do
     let(:member) { double(:member, id: 1, name: 'Justin Morris') }
     let(:other_member) { double(:other_member, id: 2, name: 'Gus Gollings') }
 
-    context 'when following is inactive' do
+    describe 'when the member already follows the other member' do
       before do
-        $switch_board.stub(:following_active?) { false }
+        other_member.stub(:follows?).with(member) { true }
       end
 
-      it { should be_nil }
+      it { should == 'Gus Gollings follows you' }
     end
 
-    context 'when following is active' do
+    describe 'when the member does not follow the other member' do
       before do
-        $switch_board.stub(:following_active?) { true }
+        other_member.stub(:follows?).with(member) { false }
       end
 
-      describe 'when the member already follows the other member' do
-        before do
-          other_member.stub(:follows?).with(member) { true }
-        end
-
-        it { should == 'Gus Gollings follows you' }
-      end
-
-      describe 'when the member does not follow the other member' do
-        before do
-          other_member.stub(:follows?).with(member) { false }
-        end
-
-        it { should == 'Gus Gollings doesn’t follow you' }
-      end
+      it { should == 'Gus Gollings doesn’t follow you' }
     end
   end
 end

--- a/spec/view_controllers/dashboards/show_spec.rb
+++ b/spec/view_controllers/dashboards/show_spec.rb
@@ -14,13 +14,6 @@ describe Dashboards::Show do
   let(:activity_1) { double(:activity_1, cache_key: 1, date: Date.today) }
   let(:activity_2) { double(:activity_2, cache_key: 2, date: Date.today) }
 
-  let(:following_active) { true }
-
-  before do
-    $switch_board ||= Class.new
-    $switch_board.stub(:following_active?) { following_active }
-  end
-
   describe '#cache_key' do
     subject(:cache_key) { view.cache_key }
 
@@ -45,37 +38,14 @@ describe Dashboards::Show do
         ActiveRecordArrayWithKaminari.new([activity_1])
       end
 
-      context 'and following is active' do
-        let(:following_active) { true }
-
-        before do
-          controller.should_receive(:render).with(render_params) do
-            ['render']
-          end
-        end
-
-        it 'should render the activities' do
-          render_activities.should == 'render'
+      before do
+        controller.should_receive(:render).with(render_params) do
+          ['render']
         end
       end
 
-      context 'and following is not active' do
-        let(:following_active) { false }
-
-        let(:member) { double(:member, activities: activities) }
-        let(:activities) do
-          double(:activities, exclude_following: member_activities)
-        end
-
-        before do
-          controller.should_receive(:render).with(render_params) do
-            ['render']
-          end
-        end
-
-        it 'should render the activities' do
-          render_activities.should == 'render'
-        end
+      it 'should render the activities' do
+        render_activities.should == 'render'
       end
     end
 

--- a/spec/view_controllers/members/show_spec.rb
+++ b/spec/view_controllers/members/show_spec.rb
@@ -27,13 +27,10 @@ describe Members::Show do
 
   let(:workout_1) { double(:workout_1, cache_key: 'a1', date: Date.today) }
   let(:workout_2) { double(:workout_2, cache_key: 'a2', date: Date.today) }
-  let(:following_active) { true }
 
   before do
     stub_const('User', Class.new)
     User.should_receive(:find).with(member_id) { member }
-    $switch_board ||= Class.new
-    $switch_board.stub(:following_active?) { following_active }
   end
 
   describe '#cache_key' do


### PR DESCRIPTION
Does what it says on the tin. Removes everything to do with having the `:following` feature flip in place:
- Remove the flip from `SwitchBoard`.
- Remove the `exclude_following` scope from the `Activity` model.
- Remove before filters on the `follow` and `unfollow` methods in the `MembersController`.
- Remove `render_404` from `MembersController` as it is no longer required.
- Remove the code that short circuits the `following_link_for_members` and `member_relationship_status_for_members` in `FollowingHelper`.
- `member_activities` in `ViewControllers::Dashboard::Show` returns all activities now instead of differentiating based on the flip.
- Remove tests around when the feature is off.
- Remove context blocks around around when the feature is on, it's now the default state.
- Remove step definitions that are no longer used without the feature flip.
- Remove `@flip @on` and `@flip @off` tags on features.

So that was actually quite a bit of code debt right there.
