### PR TITLE
Allow beta users to sign up if they know the token.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ STATIC_SITE_URL = "http://aerobic.io/"
 FIT_SERVICE_HOST = 'localhost'
 FIT_SERVICE_PORT = 3000
 FIT_SERVICE_API_TOKEN = 'lol'
+BETA_TOKEN='foobar'

--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -4,11 +4,18 @@
 #
 class IdentitiesController < ApplicationController
   skip_before_action :login_required, if: -> { $switch_board.sign_up_active? }
+  skip_before_action :login_required, if: -> { beta_token_matches? }
 
   layout 'unauthenticated'
 
   def new
     @view = Identities::New.new(self, env['omniauth.identity'])
     render layout: 'authentication'
+  end
+
+  private
+
+  def beta_token_matches?
+    !ENV['BETA_TOKEN'].blank? && params[:token] == ENV['BETA_TOKEN']
   end
 end

--- a/spec/controllers/identities_controller_spec.rb
+++ b/spec/controllers/identities_controller_spec.rb
@@ -16,10 +16,41 @@ describe IdentitiesController do
     context 'when sign up is not active' do
       before do
         $switch_board.stub(:sign_up_active?) { false }
-        get :new
       end
 
-      it { should redirect_to(sign_in_path) }
+      context 'and no token param is set' do
+        before do
+          get :new
+        end
+
+        it { should redirect_to(sign_in_path) }
+      end
+
+      context 'and ENV["BETA_TOKEN"] is not set' do
+        before do
+          ENV.stub('BETA_TOKEN') { nil }
+          get :new
+        end
+
+        it { should redirect_to(sign_in_path) }
+      end
+
+      context 'and the token param is set to an unrecognised value' do
+        before do
+          get :new, token: ENV['BETA_TOKEN'].dup.reverse!
+        end
+
+        it { should redirect_to(sign_in_path) }
+      end
+
+      context 'and the token param is set to ENV["BETA_TOKEN"]' do
+        before do
+          get :new, token: ENV['BETA_TOKEN']
+        end
+
+        it { should respond_with(:success) }
+        it { should render_template(:new) }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR enables users to visit the signup link if they provide the `token` param and it matches `ENV['BETA_TOKEN']`.

It will not modify behaviour of `ENV['BETA_TOKEN']` is not set, so this is safe to merge and deploy.

We can then generate a token and set it before emailing JBSECT.
