### PR TITLE
Add current_user.cached_key to the grouped activity/workout cache key.

### DIFF
--- a/app/views/activity/_grouped.html.erb
+++ b/app/views/activity/_grouped.html.erb
@@ -1,6 +1,6 @@
 <ol class="grouped-list">
   <% grouped.each do |group| %>
-    <% cache group.second.map(&:cache_key).join(":") do %>
+    <% cache group.second.map(&:cache_key).join(":") + current_user.cache_key do %>
       <li class="grouped-list__group">
         <h6 class="grouped-list__group__heading">
           <%= group.first.to_formatted_s(:long) %>

--- a/app/views/workouts/_grouped.html.erb
+++ b/app/views/workouts/_grouped.html.erb
@@ -1,6 +1,6 @@
 <ol class="grouped-list">
   <% grouped.each do |group| %>
-    <% cache group.second.map(&:cache_key).join(":") do %>
+    <% cache group.second.map(&:cache_key).join(":") + current_user.cache_key do %>
       <li class="grouped-list__group">
         <h6 class="grouped-list__group__heading">
           <%= group.first.to_formatted_s(:long) %>


### PR DESCRIPTION
This ensures that we render the contextual you/name stuff properly when using
russion doll cacheing.

There is another problem to solve, in that using the current_user.cache_key
results in a separate fragment per user and no shared fragments accross users.

I'll deal with that later.
