### PR TITLE
Store beta token in session.

### DIFF
--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -5,6 +5,9 @@
 class IdentitiesController < ApplicationController
   skip_before_action :login_required, if: -> { $switch_board.sign_up_active? }
   skip_before_action :login_required, if: -> { beta_token_matches? }
+  skip_before_action :login_required, if: -> { beta_token_in_session? }
+
+  before_action :add_beta_token_to_session, if: -> { beta_token_matches? }
 
   layout 'unauthenticated'
 
@@ -17,5 +20,13 @@ class IdentitiesController < ApplicationController
 
   def beta_token_matches?
     !ENV['BETA_TOKEN'].blank? && params[:token] == ENV['BETA_TOKEN']
+  end
+
+  def beta_token_in_session?
+    !ENV['BETA_TOKEN'].blank? && session[:beta_token] == ENV['BETA_TOKEN']
+  end
+
+  def add_beta_token_to_session
+    session[:beta_token] = params[:token]
   end
 end


### PR DESCRIPTION
This allows us to skip the login_required before filter should the user have
errors in the sign up form and be redirected.
